### PR TITLE
deprecated CUDA docker image was replaced

### DIFF
--- a/src/llm_vicuna.py
+++ b/src/llm_vicuna.py
@@ -30,7 +30,7 @@ def download_model():
 
 stub.vicuna_image = (
     Image.from_dockerhub(
-        "nvidia/cuda:11.7.0-devel-ubuntu20.04",
+        "nvidia/cuda:11.7.1-devel-ubuntu20.04",
         setup_dockerfile_commands=[
             "RUN apt-get update",
             "RUN apt-get install -y python3 python3-pip python-is-python3",


### PR DESCRIPTION
The current cuda-devel docker image is no longer on docker hub. I've updated the code with the updated version (the closest one to the current version).