### PR TITLE
pin pytorch version, update remote_gen

### DIFF
--- a/src/llm_vicuna.py
+++ b/src/llm_vicuna.py
@@ -41,6 +41,11 @@ stub.vicuna_image = (
         "git clone https://github.com/thisserand/FastChat.git",
         "cd FastChat && pip install -e .",
     )
+    .pip_install(
+        "torch==2.0.1",
+        "torchvision==0.15.2",
+        "torchaudio==2.0.2",
+    )
     .run_commands(
         # FastChat hard-codes a path for GPTQ, so this needs to be cloned inside repositories.
         "git clone https://github.com/oobabooga/GPTQ-for-LLaMa.git -b cuda /FastChat/repositories/GPTQ-for-LLaMa",
@@ -123,5 +128,5 @@ class Vicuna:
 @stub.local_entrypoint()
 def main(input: str):
     model = Vicuna()
-    for val in model.generate.remote(input):
+    for val in model.generate.remote_gen(input):
         print(val, end="", flush=True)


### PR DESCRIPTION
pytorch version reference: https://pytorch.org/get-started/previous-versions/#linux-and-windows-7

confirmed was able to serve and deploy locally:
<img width="1446" alt="Screen Shot 2024-01-31 at 4 18 49 PM" src="https://github.com/modal-labs/quillman/assets/1820651/e7d74f3c-4d34-452d-9d4a-179fad19400f">
<img width="1552" alt="Screen Shot 2024-01-31 at 4 24 13 PM" src="https://github.com/modal-labs/quillman/assets/1820651/86547ea7-f522-4157-a18d-3df82ddff49c">
