### PR TITLE
install fastAPI in images

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -9,11 +9,15 @@ from .common import app
 
 static_path = Path(__file__).with_name("frontend").resolve()
 
+
 @app.function(
     mounts=[modal.Mount.from_local_dir(static_path, remote_path="/assets")],
     container_idle_timeout=600,
     timeout=600,
     allow_concurrent_inputs=100,
+    image=modal.Image.debian_slim(python_version="3.11").pip_install(
+        "fastapi==0.115.5"
+    ),
 )
 @modal.asgi_app()
 def web():

--- a/src/moshi.py
+++ b/src/moshi.py
@@ -12,6 +12,7 @@ image = (
     modal.Image.debian_slim(python_version="3.11")
     .pip_install(
         "moshi==0.1.0",
+        "fastapi==0.115.5",
         "huggingface_hub==0.24.7",
         "hf_transfer==0.1.8",
         "sphn==0.1.4",


### PR DESCRIPTION
this is required with the latest image builder config