### PR TITLE
actually deploy app in CD

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -23,4 +23,4 @@ jobs:
       - name: Deploy
         run: |
           modal token set --token-id $MODAL_TOKEN_ID --token-secret $MODAL_TOKEN_SECRET
-          modal deploy
+          modal deploy src.app


### PR DESCRIPTION
cc @erik-dunteman, we were just running `modal deploy` with no arguments. exit code is non-error, but nothing happens, cf previous runs of the Deploy/`cd` workflow.