### PR TITLE
unflake

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -25,5 +25,9 @@ jobs:
         run: |
           pip install -r requirements/requirements-dev.txt
           modal token set --token-id $MODAL_TOKEN_ID --token-secret $MODAL_TOKEN_SECRET
-          modal serve -m src.app &
+          modal serve -m src.app > /tmp/modal_serve.log 2>&1 &
+          # Wait for the dev endpoint to be registered before starting the test.
+          # Without this, the test races modal-serve registration and the WS
+          # handshake can return 404.
+          timeout 120 bash -c 'until grep -q "Serving" /tmp/modal_serve.log 2>/dev/null; do sleep 1; done'
           python tests/e2e_test.py

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -25,9 +25,7 @@ jobs:
         run: |
           pip install -r requirements/requirements-dev.txt
           modal token set --token-id $MODAL_TOKEN_ID --token-secret $MODAL_TOKEN_SECRET
-          modal serve -m src.app > /tmp/modal_serve.log 2>&1 &
-          # Wait for the dev endpoint to be registered before starting the test.
-          # Without this, the test races modal-serve registration and the WS
-          # handshake can return 404.
+          modal serve -m src.app 2>&1 | tee /tmp/modal_serve.log &
+          # Wait for the server to be ready before starting the test
           timeout 120 bash -c 'until grep -q "Serving" /tmp/modal_serve.log 2>/dev/null; do sleep 1; done'
           python tests/e2e_test.py

--- a/tests/e2e_test.py
+++ b/tests/e2e_test.py
@@ -12,20 +12,26 @@ endpoint = "wss://modal-labs--quillman-moshi-web-dev.modal.run/"
 
 shutdown_flag = asyncio.Event()
 
-WARMUP_TIMEOUT = 60 # give server 60 seconds to warm up
+WARMUP_TIMEOUT = 180 # cold boot can include HF download + GPU warmup
 async def ensure_server_ready():
+    # Probe the websocket route directly — that's what the test actually needs,
+    # and during dev-function (re)registration GET /status can return 200 even
+    # while a WS upgrade to /ws still 404s.
     deadline = time.time() + WARMUP_TIMEOUT
-    async with aiohttp.ClientSession() as session:
-        while time.time() < deadline:
-            try:
-                print("Checking server status...")
-                resp = await session.get(endpoint + "status")
-                if resp.status == 200:
+    while time.time() < deadline:
+        try:
+            print("Probing server with ws_connect...")
+            async with aiohttp.ClientSession() as session:
+                async with session.ws_connect(
+                    endpoint + "ws",
+                    timeout=aiohttp.ClientTimeout(total=60),
+                ):
+                    print("Server ready.")
                     return
-            except Exception as e:
-                print("Error while checking server status:", e)
-                await asyncio.sleep(5)
-                pass
+        except Exception as e:
+            print("Server not ready yet:", e)
+            await asyncio.sleep(5)
+    raise RuntimeError(f"Server did not become ready within {WARMUP_TIMEOUT}s")
 
 async def run():
     await ensure_server_ready()

--- a/tests/e2e_test.py
+++ b/tests/e2e_test.py
@@ -14,9 +14,6 @@ shutdown_flag = asyncio.Event()
 
 WARMUP_TIMEOUT = 180 # cold boot can include HF download + GPU warmup
 async def ensure_server_ready():
-    # Probe the websocket route directly — that's what the test actually needs,
-    # and during dev-function (re)registration GET /status can return 200 even
-    # while a WS upgrade to /ws still 404s.
     deadline = time.time() + WARMUP_TIMEOUT
     while time.time() < deadline:
         try:


### PR DESCRIPTION
"We" implemented a fix to make CI stop flaking. Issue was due to a race condition in modal getting the dev server up fast enough before the e2e test runs